### PR TITLE
Haxe 4 compat fixes

### DIFF
--- a/src/parsihax/Parser.hx
+++ b/src/parsihax/Parser.hx
@@ -115,7 +115,7 @@ class Parser {
     in case of matching single character.
   **/
   public static function char(character : String) : ParseObject<String> {
-    return function(ch) { return character == ch; }.test().as("'"+character+"'");
+    return (function(ch) { return character == ch; }).test().as("'"+character+"'");
   }
 
   /**
@@ -123,7 +123,7 @@ class Parser {
     yields that character.
   **/
   public static function oneOf(string : String) : ParseObject<String> {
-    return function(ch) { return string.indexOf(ch) >= 0; }.test();
+    return (function(ch) { return string.indexOf(ch) >= 0; }).test();
   }
 
   /**
@@ -131,7 +131,7 @@ class Parser {
     and yields that character.
   **/
   public static function noneOf(string : String) : ParseObject<String> {
-    return function(ch) { return string.indexOf(ch) < 0; }.test();
+    return (function(ch) { return string.indexOf(ch) < 0; }).test();
   }
 
   /**

--- a/test.hxml
+++ b/test.hxml
@@ -3,4 +3,5 @@
 -lib monax
 -lib buddy
 -main parsihax.Test
--x test/parsihax/Test
+-neko test/parsihax/Test.n
+-cmd neko test/parsihax/Test.n

--- a/test/parsihax/JsonGrammar.hx
+++ b/test/parsihax/JsonGrammar.hx
@@ -9,7 +9,7 @@ enum JsonExpression {
   JsonNull;
   JsonTrue;
   JsonFalse;
-  JsonNumber(v : Int);
+  JsonNumber(v : Float);
   JsonString(v : String);
   JsonPair(k : JsonExpression, v : JsonExpression);
   JsonArray(v : Array<JsonExpression>);
@@ -18,7 +18,7 @@ enum JsonExpression {
 
 class JsonGrammar {
   // This is the main entry point of the parser: a full Json document.
-  static var json = function() {
+  static var json = (function() {
     return whitespace.then([
       object,
       array,
@@ -28,7 +28,7 @@ class JsonGrammar {
       trueLiteral,
       falseLiteral
     ].alt());
-  }.lazy();
+  }).lazy();
 
   // Use the Json standard's definition of whitespace rather than Parsihax's.
   static var whitespace = ~/\s*/m.regexp();


### PR DESCRIPTION
 * `function(){}.xyz` -> `(function(){}).xyz`
 * `-x` is deprecated, use `-neko` + `-cmd`
 * JsonNumber should hold a Float instead of an Int